### PR TITLE
[FileStorage] Fix handling of multiple containers.

### DIFF
--- a/Lokad.AzureEventStore/StorageConfiguration.cs
+++ b/Lokad.AzureEventStore/StorageConfiguration.cs
@@ -71,8 +71,8 @@ namespace Lokad.AzureEventStore
             }
             else
             {
-                var filePath = string.IsNullOrWhiteSpace(cname) ? cs : Path.Combine(cs, cname);
-                driver = new FileStorageDriver(cs);
+                string filePath = string.IsNullOrWhiteSpace(cname) ? cs : Path.Combine(cs, cname);
+                driver = new FileStorageDriver(filePath);
             }
             
             if (Trace)


### PR DESCRIPTION
When setting a storage configuration accessing local files, the
container part used to be stripped.
Creating the FileStorage back-end file inside a sub-directory named
after the container enables to use concurrently access to different
containers without facing IOExceptions.