### PR TITLE
enhance Azure state cache container creation

### DIFF
--- a/Lokad.AzureEventStore.Cache/AzureCacheProvider.cs
+++ b/Lokad.AzureEventStore.Cache/AzureCacheProvider.cs
@@ -53,7 +53,11 @@ namespace Lokad.AzureEventStore.Cache
         /// </remarks>
         private async Task<CloudBlockBlob[]> Blobs(string stateName)
         {
-            await _container.CreateIfNotExistsAsync();
+            // Attempting to create the container if it doesn't exist allows
+            // to jump-start a state from existing caches only letting the
+            // upload of a refreshed state to fail.
+            if (AllowWrite && ! await _container.ExistsAsync().ConfigureAwait(false))
+                await _container.CreateIfNotExistsAsync().ConfigureAwait(false);
 
             var result = new List<CloudBlockBlob>();
 

--- a/Lokad.AzureEventStore.Cache/AzureCacheProvider.cs
+++ b/Lokad.AzureEventStore.Cache/AzureCacheProvider.cs
@@ -53,6 +53,8 @@ namespace Lokad.AzureEventStore.Cache
         /// </remarks>
         private async Task<CloudBlockBlob[]> Blobs(string stateName)
         {
+            // Calling CreateIfNotExists with insufficient privilege will
+            // throw an exception _even if_ the container _exists_.
             // Attempting to create the container only if it doesn't exist
             // allows to read existing state caches even if the caller does not
             // have sufficient permission to create the container.

--- a/Lokad.AzureEventStore.Cache/AzureCacheProvider.cs
+++ b/Lokad.AzureEventStore.Cache/AzureCacheProvider.cs
@@ -53,9 +53,9 @@ namespace Lokad.AzureEventStore.Cache
         /// </remarks>
         private async Task<CloudBlockBlob[]> Blobs(string stateName)
         {
-            // Attempting to create the container if it doesn't exist allows
-            // to jump-start a state from existing caches only letting the
-            // upload of a refreshed state to fail.
+            // Attempting to create the container only if it doesn't exist
+            // allows to read existing state caches even if the caller does not
+            // have sufficient permission to create the container.
             if (AllowWrite && ! await _container.ExistsAsync().ConfigureAwait(false))
                 await _container.CreateIfNotExistsAsync().ConfigureAwait(false);
 


### PR DESCRIPTION
Only attempt to create the state cache Azure container if the provider
is allowed to write and only if it doesn't already exists.
This allows to access existing cache even if the container access is
read-only.
It makes it perfect for quick and safe tests.